### PR TITLE
Fixes misspelt blockquote tag

### DIFF
--- a/lib/rich_text_renderer/block_renderers/blockquote_renderer.rb
+++ b/lib/rich_text_renderer/block_renderers/blockquote_renderer.rb
@@ -6,7 +6,7 @@ module RichTextRenderer
     protected
 
     def render_tag
-      'blockqoute'
+      'blockquote'
     end
   end
 end

--- a/spec/lib/rich_text_renderer/block_renderers/blockquote_renderer_spec.rb
+++ b/spec/lib/rich_text_renderer/block_renderers/blockquote_renderer_spec.rb
@@ -14,12 +14,12 @@ describe RichTextRenderer::BlockQuoteRenderer do
   end
 
   describe '#render' do
-    it 'renders a blockqoute' do
-      expect(subject.render(mock_node)).to eq "<blockqoute><p>foo</p></blockqoute>"
+    it 'renders a blockquote' do
+      expect(subject.render(mock_node)).to eq "<blockquote><p>foo</p></blockquote>"
     end
 
     it 'will propagate marks to text renderers' do
-      expect(subject.render(mock_node_with_marks)).to eq "<blockqoute><p><b>foo</b></p></blockqoute>"
+      expect(subject.render(mock_node_with_marks)).to eq "<blockquote><p><b>foo</b></p></blockquote>"
     end
   end
 end


### PR DESCRIPTION
The rich text renderer generates blockquote tags as "blockqoute". This fixes that.
The delightful irony that is my typo in the fix commit message is not unnoticed.